### PR TITLE
Include support for Type conversion when using Set.

### DIFF
--- a/Heleonix.Reflection.Tests/Common/Dummies/EnumItem.cs
+++ b/Heleonix.Reflection.Tests/Common/Dummies/EnumItem.cs
@@ -1,0 +1,28 @@
+// <copyright file="EnumItem.cs" company="Heleonix - Hennadii Lutsyshyn">
+// Copyright (c) 2017-present Heleonix - Hennadii Lutsyshyn. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the repository root for full license information.
+// </copyright>
+
+namespace Heleonix.Reflection.Tests.Common.Dummies
+{
+    /// <summary>
+    /// The enum item type
+    /// </summary>
+    public enum EnumItem
+    {
+        /// <summary>
+        /// value 1
+        /// </summary>
+        Value1,
+
+        /// <summary>
+        /// value 2
+        /// </summary>
+        Value2,
+
+        /// <summary>
+        /// value 3
+        /// </summary>
+        Value3
+    }
+}

--- a/Heleonix.Reflection.Tests/Common/Dummies/SubSubItem.cs
+++ b/Heleonix.Reflection.Tests/Common/Dummies/SubSubItem.cs
@@ -5,6 +5,7 @@
 
 namespace Heleonix.Reflection.Tests.Common.Dummies
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -60,6 +61,16 @@ namespace Heleonix.Reflection.Tests.Common.Dummies
         /// Gets or sets the object.
         /// </summary>
         public object ObjectProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the enum.
+        /// </summary>
+        public EnumItem EnumProperty { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Date.
+        /// </summary>
+        public DateTime DateProperty { get; set; }
 
         /// <summary>
         /// Gets or sets an item by the specified index.

--- a/Heleonix.Reflection.Tests/ReflectorTests.cs
+++ b/Heleonix.Reflection.Tests/ReflectorTests.cs
@@ -711,6 +711,34 @@ namespace Heleonix.Reflection.Tests
                                 Assert.That(returnValue, Is.True);
                             });
 
+                            And("property is an enum and value is string", () =>
+                            {
+                                memberPath = "SubItemProperty.SubSubItemProperty.EnumProperty";
+                                value = "Value2";
+
+                                Should("set the enum value and return true", () =>
+                                {
+                                    Assert.That(
+                                        instance.SubItemProperty.SubSubItemProperty.EnumProperty,
+                                        Is.EqualTo(EnumItem.Value2));
+                                    Assert.That(returnValue, Is.True);
+                                });
+                            });
+
+                            And("property is of type DateTime and value is string", () =>
+                            {
+                                memberPath = "SubItemProperty.SubSubItemProperty.DateProperty";
+                                value = "2010-3-23";
+
+                                Should("set the date value and return true", () =>
+                                {
+                                    Assert.That(
+                                        instance.SubItemProperty.SubSubItemProperty.DateProperty,
+                                        Is.EqualTo(DateTime.Parse(value.ToString())));
+                                    Assert.That(returnValue, Is.True);
+                                });
+                            });
+
                             And("property does not have setter", () =>
                             {
                                 memberPath = "SubItemProperty.SubSubItemProperty.StaticTextGetProperty";

--- a/Heleonix.Reflection/Reflector.cs
+++ b/Heleonix.Reflection/Reflector.cs
@@ -986,7 +986,7 @@ namespace Heleonix.Reflection
                 return null;
             }
 
-            if (memberType.IsInstanceOfType(value))
+            if (memberType.GetTypeInfo().IsInstanceOfType(value))
             {
                 return value;
             }

--- a/Heleonix.Reflection/Reflector.cs
+++ b/Heleonix.Reflection/Reflector.cs
@@ -985,6 +985,12 @@ namespace Heleonix.Reflection
             {
                 throw new ArgumentNullException(nameof(value));
             }
+
+            if (memberType.IsInstanceOfType(value))
+            {
+                return value;
+            }
+
 #if !NETSTANDARD1_6
             var converter = TypeDescriptor.GetConverter(memberType);
             if (!converter.CanConvertFrom(value.GetType()))

--- a/Heleonix.Reflection/Reflector.cs
+++ b/Heleonix.Reflection/Reflector.cs
@@ -983,7 +983,7 @@ namespace Heleonix.Reflection
         {
             if (value is null)
             {
-                throw new ArgumentNullException(nameof(value));
+                return null;
             }
 
             if (memberType.IsInstanceOfType(value))


### PR DESCRIPTION
In the spirit of this library supporting dynamic, string member paths, this enables it to also support string values as well.
In situations where your member name, and values are coming from string sources (like script or json), this fills a missing gap in functionality.

This leverages flexible `TypeDescriptor` where it can for conversion, falling back to `ChangeType` for netstandard1.6.